### PR TITLE
Fixed small design issues in file view

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -170,4 +170,6 @@
 
 .btn-input-copy {
   margin-left: -5px;
+  padding-bottom: 9px;
+  padding-top: 3px;
 }

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -153,7 +153,6 @@
 }
 
 .div-input {
-  cursor: copy !important;
   border: 1px solid #CCC;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -94,6 +94,9 @@
 .nav {
   margin-bottom: 10px;
 }
+.nav-tabs>li{
+  cursor: pointer;
+}
 .storefor {
   margin-top: 10px;
 }

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -105,6 +105,12 @@
   font-size: 50%;
 }
 
+.icon-spinner:before{
+	height: 20px;
+	width: 20px;
+	font-size: 10px;
+}
+
 // Animation from Font-Awesome
 .animate-spin {
   -moz-animation: spin 2s infinite linear;
@@ -112,6 +118,7 @@
   -webkit-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
   display: inline-block;
+  line-height: 0px;
 }
 @-moz-keyframes spin {
   0% {

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -109,9 +109,9 @@
 }
 
 .icon-spinner:before{
-	height: 20px;
-	width: 20px;
-	font-size: 10px;
+  height: 20px;
+  width: 20px;
+  font-size: 10px;
 }
 
 // Animation from Font-Awesome

--- a/src/partials/view.html
+++ b/src/partials/view.html
@@ -1,5 +1,5 @@
 <div class="row text-center" ng-show="images[0] == undefined">
-  <h4><i class="icon-spinner animate-spin"></i> <span translate>Loading</span></h4>
+  <h4><div class="icon-spinner animate-spin"></div> <span translate>Loading</span></h4>
 </div>
 
 <div ng-init="images = []">


### PR DESCRIPTION
Fixed:
1. Annoying cursor (it's not nice to mark text with that cursor)
2. Centred the copy icons - but these ones aren't working anyway, so they would need a major redesign. (see https://github.com/imgbi/img.bi/issues/44)
3. Adjusted the spinner so that it rotates correctly. Now it's like this:
![imgbi_loadingspinner](https://cloud.githubusercontent.com/assets/12105354/7799588/3ac9d610-0308-11e5-8a3b-2582b4f29cc2.PNG)
4. Adjusted the cursor for the tabs.