### PR TITLE
Add prefix for local storage

### DIFF
--- a/frontend/scripts/controllers.js
+++ b/frontend/scripts/controllers.js
@@ -131,12 +131,12 @@ angular.module('imgbi.controllers', [])
       };
       getFullStorage().then(function(storage) {
         angular.forEach(storage, function(content, id) {
-          if (id != 'lang' && id != 'expire') {
+          if (id.substring(0, 6) == 'imgbi_' && id != 'imgbi_lang' && id != 'imgbi_expire') {
             if (typeof content !== 'object') {
               content = JSON.parse(content);
             }
             $rootScope.thumbs.push({
-              id: id,
+              id: id.substring(6, id.length),
               pass: content.pass,
               rmpass: content.rmpass
             });

--- a/frontend/scripts/storage.js
+++ b/frontend/scripts/storage.js
@@ -9,16 +9,16 @@ angular.module('imgbi.storage', [])
       if (typeof value === 'object') {
         value = JSON.stringify(value);
       }
-      localStorage.setItem(id, value);
+      localStorage.setItem('imgbi_' + id, value);
     };
   }])
   .factory('getStorage', ['$q', function($q) {
     return function(id) {
       var deferred = $q.defer();
       if (id != 'lang' && id != 'expire') {
-        deferred.resolve(JSON.parse(localStorage.getItem(id)));
+        deferred.resolve(JSON.parse(localStorage.getItem('imgbi_' + id)));
       } else {
-        deferred.resolve(localStorage.getItem(id));
+        deferred.resolve(localStorage.getItem('imgbi_' + id));
       }
       return deferred.promise;
     };


### PR DESCRIPTION
Fixes https://github.com/imgbi/img.bi/issues/65

However I admit that it is not nice that `getFullStorage` still returns the values prefixed, but it is only used once in the Controller, so it was the easiest (hackish) method to just use the already existent loop there to remove the prefix.
If you'll fix this in a better way I have nothing against it! :smiley: 

Possibly it would also be a good idea to make "imgbi_" a (global) variable, so that a server admin can change it if it is suitable.